### PR TITLE
feature: Zooming

### DIFF
--- a/src/components/DrawControls.tsx
+++ b/src/components/DrawControls.tsx
@@ -50,7 +50,7 @@ function DrawControls(props: CanvasProps & DrawControlProps) {
                    props.context.lineWidth = props.currentCoordPath.width;
                    props.popStack();
                    drawFromBuffer(props.context, props.canvas,
-                                  props.canvasOffset, props.buffer);
+                                  props.canvasOffset, props.buffer, props.canvasScale);
              } else {
                  setUndoDisabled(true);
              }

--- a/src/components/Paint.tsx
+++ b/src/components/Paint.tsx
@@ -296,11 +296,16 @@ function Paint(props: PaintProps) {
                         const bounds = canvas.getBoundingClientRect();
 
                         // Calculate the mouse position relative to the buffer
+                        const scaledWidth  = canvas.width  * scale.current,
+                              scaledHeight = canvas.height * scale.current;
+                        const scaledOffsetX = canvasOffset.x + 0.5 * (canvas.width  - scaledWidth),
+                              scaledOffsetY = canvasOffset.y + 0.5 * (canvas.height - scaledHeight);
+
                         mousePos.current = { x: e.clientX - bounds.left,
                                              y: e.clientY - bounds.top };
                         isDrawing.current = true;
-                        currentCoordPath.current.pos = [ { x: mousePos.current.x + canvasOffset.x,
-                                                           y: mousePos.current.y + canvasOffset.y } ];
+                        currentCoordPath.current.pos = [ { x: scale.current * mousePos.current.x + scaledOffsetX,
+                                                           y: scale.current * mousePos.current.y + scaledOffsetY } ];
                         coordPathLen.current = 0;
                         debug('start draw: ' + mousePos.current.x + ', ' + mousePos.current.y);
                         setCanUndo(false);
@@ -379,8 +384,12 @@ function Paint(props: PaintProps) {
                                 context.strokeStyle = currentCoordPath.current.color;
                                 drawLine(context, mousePos.current, end, currentCoordPath.current.width);
 
-                                currentCoordPath.current.pos.push({ x: end.x + canvasOffset.x, 
-                                                                    y: end.y + canvasOffset.y });
+                                const scaledWidth  = canvas.width  * scale.current,
+                                      scaledHeight = canvas.height * scale.current;
+                                const scaledOffsetX = canvasOffset.x + 0.5 * (canvas.width  - scaledWidth),
+                                      scaledOffsetY = canvasOffset.y + 0.5 * (canvas.height - scaledHeight);
+                                currentCoordPath.current.pos.push({ x: scale.current * end.x + scaledOffsetX, 
+                                                                    y: scale.current * end.y + scaledOffsetY });
                                 coordPathLen.current += distance(mousePos.current, end);
 
                                 if (props.maxStrokeLen && coordPathLen.current >= props.maxStrokeLen) {
@@ -411,9 +420,14 @@ function Paint(props: PaintProps) {
                             return;
                         }
 
+                        const scaledWidth  = canvas.width  * scale.current,
+                              scaledHeight = canvas.height * scale.current;
+                        const scaledOffsetX = canvasOffset.x + 0.5 * (canvas.width  - scaledWidth),
+                              scaledOffsetY = canvasOffset.y + 0.5 * (canvas.height - scaledHeight);
+
                         isDrawing.current = true;
-                        currentCoordPath.current.pos = [ { x: touchPos.current.x + canvasOffset.x,
-                                                           y: touchPos.current.y + canvasOffset.y } ];
+                        currentCoordPath.current.pos = [ { x: scale.current * touchPos.current.x + scaledOffsetX,
+                                                           y: scale.current * touchPos.current.y + scaledOffsetY } ];
                         coordPathLen.current = 0;
                         debug('start draw: ' + touchPos.current.x + ', ' + touchPos.current.y);
                         setCanUndo(false);
@@ -481,8 +495,14 @@ function Paint(props: PaintProps) {
                                 context.strokeStyle = currentCoordPath.current.color;
                                 drawLine(context, touchPos.current, lastTouchPos, currentCoordPath.current.width);
 
-                                currentCoordPath.current.pos.push({ x: lastTouchPos.x + canvasOffset.x,
-                                                                    y: lastTouchPos.y + canvasOffset.y });
+                                const scaledWidth  = canvas.width  * scale.current,
+                                      scaledHeight = canvas.height * scale.current;
+                                const scaledOffsetX = canvasOffset.x + 0.5 * (canvas.width  - scaledWidth),
+                                      scaledOffsetY = canvasOffset.y + 0.5 * (canvas.height - scaledHeight);
+
+
+                                currentCoordPath.current.pos.push({ x: scale.current * lastTouchPos.x + scaledOffsetX,
+                                                                    y: scale.current * lastTouchPos.y + scaledOffsetY });
                                 coordPathLen.current += distance(touchPos.current, lastTouchPos);
 
                                 if (props.maxStrokeLen && coordPathLen.current >= props.maxStrokeLen) {

--- a/src/components/Paint.tsx
+++ b/src/components/Paint.tsx
@@ -13,6 +13,7 @@ import {
     drawAllCurvesFromStack,
     drawFromBuffer,
     panCanvas,
+    getScaledOffset,
     stackIncludesPath
 } from '../utils/PaintUtils';
 import {
@@ -88,7 +89,7 @@ function Paint(props: PaintProps) {
     const sendLoaded = () => { props.loaded(); }
 
     const setMaxScale = () => {
-        if (canvas.width > canvas.height)
+        if (canvas.height > canvas.width)
             maxScale.current = props.maxHeight / canvas.height;
         else
             maxScale.current = props.maxWidth / canvas.width;
@@ -300,14 +301,13 @@ function Paint(props: PaintProps) {
                         // Calculate the mouse position relative to the buffer
                         const scaledWidth  = canvas.width  * scale.current,
                               scaledHeight = canvas.height * scale.current;
-                        const scaledOffsetX = canvasOffset.x + 0.5 * (canvas.width  - scaledWidth),
-                              scaledOffsetY = canvasOffset.y + 0.5 * (canvas.height - scaledHeight);
+                        const scaledOffset = getScaledOffset(canvasOffset, scale.current, canvas, buffer);
 
                         mousePos.current = { x: e.clientX - bounds.left,
                                              y: e.clientY - bounds.top };
                         isDrawing.current = true;
-                        currentCoordPath.current.pos = [ { x: scale.current * mousePos.current.x + scaledOffsetX,
-                                                           y: scale.current * mousePos.current.y + scaledOffsetY } ];
+                        currentCoordPath.current.pos = [ { x: scale.current * mousePos.current.x + scaledOffset.x,
+                                                           y: scale.current * mousePos.current.y + scaledOffset.y } ];
                         coordPathLen.current = 0;
                         debug('start draw: ' + mousePos.current.x + ', ' + mousePos.current.y);
                         setCanUndo(false);
@@ -388,10 +388,9 @@ function Paint(props: PaintProps) {
 
                                 const scaledWidth  = canvas.width  * scale.current,
                                       scaledHeight = canvas.height * scale.current;
-                                const scaledOffsetX = canvasOffset.x + 0.5 * (canvas.width  - scaledWidth),
-                                      scaledOffsetY = canvasOffset.y + 0.5 * (canvas.height - scaledHeight);
-                                currentCoordPath.current.pos.push({ x: scale.current * end.x + scaledOffsetX, 
-                                                                    y: scale.current * end.y + scaledOffsetY });
+                                const scaledOffset = getScaledOffset(canvasOffset, scale.current, canvas, buffer);
+                                currentCoordPath.current.pos.push({ x: scale.current * end.x + scaledOffset.x, 
+                                                                    y: scale.current * end.y + scaledOffset.y });
                                 coordPathLen.current += distance(mousePos.current, end);
 
                                 if (props.maxStrokeLen && coordPathLen.current >= props.maxStrokeLen) {
@@ -435,12 +434,11 @@ function Paint(props: PaintProps) {
 
                         const scaledWidth  = canvas.width  * scale.current,
                               scaledHeight = canvas.height * scale.current;
-                        const scaledOffsetX = canvasOffset.x + 0.5 * (canvas.width  - scaledWidth),
-                              scaledOffsetY = canvasOffset.y + 0.5 * (canvas.height - scaledHeight);
+                        const scaledOffset = getScaledOffset(canvasOffset, scale.current, canvas, buffer);
 
                         isDrawing.current = true;
-                        currentCoordPath.current.pos = [ { x: scale.current * touchPos.current.x + scaledOffsetX,
-                                                           y: scale.current * touchPos.current.y + scaledOffsetY } ];
+                        currentCoordPath.current.pos = [ { x: scale.current * touchPos.current.x + scaledOffset.x,
+                                                           y: scale.current * touchPos.current.y + scaledOffset.y } ];
                         coordPathLen.current = 0;
                         debug('start draw: ' + touchPos.current.x + ', ' + touchPos.current.y);
                         setCanUndo(false);
@@ -525,12 +523,11 @@ function Paint(props: PaintProps) {
 
                                 const scaledWidth  = canvas.width  * scale.current,
                                       scaledHeight = canvas.height * scale.current;
-                                const scaledOffsetX = canvasOffset.x + 0.5 * (canvas.width  - scaledWidth),
-                                      scaledOffsetY = canvasOffset.y + 0.5 * (canvas.height - scaledHeight);
+                                const scaledOffset = getScaledOffset(canvasOffset, scale.current, canvas, buffer);
 
 
-                                currentCoordPath.current.pos.push({ x: scale.current * lastTouchPos.x + scaledOffsetX,
-                                                                    y: scale.current * lastTouchPos.y + scaledOffsetY });
+                                currentCoordPath.current.pos.push({ x: scale.current * lastTouchPos.x + scaledOffset.x,
+                                                                    y: scale.current * lastTouchPos.y + scaledOffset.y });
                                 coordPathLen.current += distance(touchPos.current, lastTouchPos);
 
                                 if (props.maxStrokeLen && coordPathLen.current >= props.maxStrokeLen) {

--- a/src/components/Paint.tsx
+++ b/src/components/Paint.tsx
@@ -382,7 +382,7 @@ function Paint(props: PaintProps) {
                                 const end: Coord = { x: e.clientX - bounds.left,
                                                      y: e.clientY - bounds.top };
                                 context.strokeStyle = currentCoordPath.current.color;
-                                drawLine(context, mousePos.current, end, currentCoordPath.current.width);
+                                drawLine(context, mousePos.current, end, currentCoordPath.current.width / scale.current);
 
                                 const scaledWidth  = canvas.width  * scale.current,
                                       scaledHeight = canvas.height * scale.current;
@@ -493,7 +493,7 @@ function Paint(props: PaintProps) {
 
                             if (isDrawing.current) {
                                 context.strokeStyle = currentCoordPath.current.color;
-                                drawLine(context, touchPos.current, lastTouchPos, currentCoordPath.current.width);
+                                drawLine(context, touchPos.current, lastTouchPos, currentCoordPath.current.width / scale.current);
 
                                 const scaledWidth  = canvas.width  * scale.current,
                                       scaledHeight = canvas.height * scale.current;

--- a/src/utils/MathUtils.ts
+++ b/src/utils/MathUtils.ts
@@ -13,6 +13,11 @@ export function distance(a: Coord, b: Coord): number {
     return Math.hypot(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
 }
 
+// Clamp a value between two bounds.
+export function clamp(val: number, min: number, max: number) {
+    return Math.max(min, Math.min(val, max));
+}
+
 // Returns true if x is beyond the horizontal bounds of the supplied Rect
 export function outOfBoundsX(x: number, bounds: Rect): boolean {
     return x < bounds.sx || x > bounds.sx + bounds.width;

--- a/src/utils/PaintUtils.ts
+++ b/src/utils/PaintUtils.ts
@@ -50,6 +50,7 @@ export interface CanvasProps {
     buffer?: HTMLCanvasElement,                 // The offscreen buffer itself
     canvasOffset?: Coord,                       // The offset of the canvas' top left corner
                                                 //  from that of the buffer canvas
+    canvasScale?: number,                       // The scale of the canvas
     currentCoordPath?: CoordPath,               // The path for the stroke being draw
     coordPathStack?: CoordPath[],               // The overall stack of paths
     cannotDraw?: boolean,                       // True if the user is to be prevented from drawing
@@ -207,12 +208,16 @@ export function undo(context: CanvasRenderingContext2D,
 export function drawFromBuffer(context: CanvasRenderingContext2D,
                                canvas: HTMLCanvasElement,
                                offset: Coord,
-                               buffer: HTMLCanvasElement) {
+                               buffer: HTMLCanvasElement,
+                               scale: number) {
     // Clear the current canvas and draw a window from the buffer according to
     // the current offset and canvas size.
     context.clearRect(0, 0, canvas.width, canvas.height);
-    context.drawImage(buffer, offset.x, offset.y, canvas.width, canvas.height,
-                      0, 0, canvas.width, canvas.height);
+    context.drawImage(buffer,
+                      offset.x, offset.y,
+                      canvas.width * scale, canvas.height * scale,
+                      0, 0,
+                      canvas.width, canvas.height);
 }
 
 // Pan on the canvas by the movement specified by movement. This essentially shifts

--- a/src/utils/PaintUtils.ts
+++ b/src/utils/PaintUtils.ts
@@ -210,12 +210,17 @@ export function drawFromBuffer(context: CanvasRenderingContext2D,
                                offset: Coord,
                                buffer: HTMLCanvasElement,
                                scale: number) {
-    // Clear the current canvas and draw a window from the buffer according to
+    const scaledWidth  = canvas.width  * scale,
+          scaledHeight = canvas.height * scale;
+    const scaledOffsetX = offset.x + 0.5 * (canvas.width  - scaledWidth),
+          scaledOffsetY = offset.y + 0.5 * (canvas.height - scaledHeight);
+
+    // Clear the current canvas and draw a scaled window from the buffer according to
     // the current offset and canvas size.
     context.clearRect(0, 0, canvas.width, canvas.height);
     context.drawImage(buffer,
-                      offset.x, offset.y,
-                      canvas.width * scale, canvas.height * scale,
+                      scaledOffsetX, scaledOffsetY,
+                      scaledWidth, scaledHeight,
                       0, 0,
                       canvas.width, canvas.height);
 }
@@ -224,13 +229,18 @@ export function drawFromBuffer(context: CanvasRenderingContext2D,
 // the offset of canvas from the top-left corner of buffer, with some checks to ensure
 // that the resulting movement does not place the canvas beyond the bounds of buffer.
 export function panCanvas(canvas: HTMLCanvasElement, buffer: HTMLCanvasElement,
-                          canvasOffset: Coord, movement: Coord) {
+                          canvasOffset: Coord, movement: Coord, scale: number) {
     canvasOffset.x -= movement.x;
     canvasOffset.y -= movement.y;
 
+    const scaledWidth  = canvas.width  * scale,
+          scaledHeight = canvas.height * scale;
+    const scaledOffsetX = canvasOffset.x + 0.5 * (canvas.width  - scaledWidth),
+          scaledOffsetY = canvasOffset.y + 0.5 * (canvas.height - scaledHeight);
+
     const bufferRect = { sx: 0, sy: 0, width: buffer.width, height: buffer.height };
-    const canvasRect = { sx: canvasOffset.x, sy: canvasOffset.y,
-                         width: canvas.width, height: canvas.height };
+    const canvasRect = { sx: scaledOffsetX, sy: scaledOffsetY,
+                         width: scaledWidth, height: scaledHeight };
 
     // If the attempted pan results in moving the canvas beyond the buffer's bounds,
     // reverse the offending movement.


### PR DESCRIPTION
- [x] Zoom in and out of canvas using scroll wheel
- [x] Correctly handle drawing of incoming strokes from server according to zoom level
- [x] Dynamically calculate zoom limits based on dimensions of visible canvas
- [x] Automatically update zoom level/offset if visible canvas dimensions change
- [x] Take zoom level into account when drawing stroke on canvas*

* Right now, when a stroke is drawn when at a zoom level that isn't 1.0x, because the drawn stroke's coordinates aren't normalized, the stroke ends up scaling and snapping to a different position.